### PR TITLE
Exposes the migration algorithm for ad-hoc testing and ad-hoc migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ engine.addMigration(2, (state) => { /* migration step for 2 */ return state; });
 engine.addMigration(3, (state) => { /* migration step for 3 */ return state; });
 ```
 
+## Testing migrations without a store (applying against ad-hoc state)
+
+```
+import {buildMigrationEngine} from 'redux-storage-decorator-migrate'
+const versionKey = 'redux-storage-decorators-migrate-version'
+ 
+const someTestState = {
+  [versionKey]: 0,
+  myFancyStateProperty: 'A'
+}
+
+const someExampleMigration = {
+  version: 1,
+  migration: (state) => ({...state, myFancyStateProperty: 'B'})
+}
+
+const migrationEngine = buildMigrationEngine(1, versionKey, [someExampleMigration])
+
+const migratedState = migrationEngine(someTestState)
+
+console.log(migratedState.myFancyStateProperty)
+// B
+```
+
 ## License
 
   MIT

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@mathieudutour/js-fatigue": "^1.0.2"
+    "@mathieudutour/js-fatigue": "^1.0.2",
+    "babel-eslint": "^7.1.0"
   },
   "peerDependencies": {
     "redux-storage": ">3.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,30 @@
-export default (engine, currentVersion = 0, key = 'redux-storage-decorators-migrate-version') => {
-  const migrations = []
+export const buildMigrationEngine = (currentVersion, key, migrations) => (state) => {
+  const fromVersion = (state && state[key]) || 0
+  let migratedState = state
+
+  const migrationsToApply = migrations.filter((migration) => {
+    return migration.version > fromVersion && migration.version <= currentVersion
+  }).sort((m1, m2) => m2.version < m1.version).map((m) => m.migration)
+
+  migrationsToApply.forEach((migration) => {
+    // Do nothing if migration returns nothing. Good for experiments.
+    // Migration isn't applied until it returns something.
+    migratedState = migration(migratedState) || migratedState
+  })
+
+  // Version doesn't belong to app state, it's meta property.
+  // Otherwise combineReducers would complain about missing reducer.
+  delete migratedState[key]
+  return migratedState
+}
+
+export default (engine, currentVersion = 0, key = 'redux-storage-decorators-migrate-version',
+                migrations = [], migrationEngine = buildMigrationEngine(currentVersion, key, migrations)) => {
   return {
     ...engine,
 
     load () {
-      return engine.load().then((state) => {
-        const fromVersion = state[key] || 0
-        let migratedState = state
-
-        const migrationsToApply = migrations.filter((migration) => {
-          return migration.version > fromVersion && migration.version <= currentVersion
-        }).sort((m1, m2) => m2.version < m1.version).map((m) => m.migration)
-
-        migrationsToApply.forEach((migration) => {
-          // Do nothing if migration returns nothing. Good for experiments.
-          // Migration isn't applied until it returns something.
-          migratedState = migration(migratedState) || migratedState
-        })
-
-        // Version doesn't belong to app state, it's meta property.
-        // Otherwise combineReducers would complain about missing reducer.
-        delete migratedState[key]
-        return migratedState
-      })
+      return engine.load().then(migrationEngine)
     },
 
     save (state) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import sinon from 'sinon'
 import 'sinon-as-promised'
 
-import migrate from '../src/'
+import migrate, {buildMigrationEngine} from '../src/'
 
 function identityStub (arg) {
   return new Promise((resolve) => resolve(arg))
@@ -106,6 +106,28 @@ test('should applied migrations to the loaded state when the current version is 
   const state = await engine.load()
 
   t.same(state, { key: 2 })
+})
+
+test('should apply migrations to ad-hoc state (for testing or for initialStates)', async (t) => {
+  t.plan(1)
+
+  const versionKey = 'redux-storage-decorators-migrate-version'
+
+  const someTestState = {
+    [versionKey]: 0,
+    myFancyStateProperty: 'A'
+  }
+
+  const someExampleMigration = {
+    version: 1,
+    migration: (state) => ({...state, myFancyStateProperty: 'B'})
+  }
+
+  const migrationEngine = buildMigrationEngine(1, versionKey, [someExampleMigration])
+
+  const migratedState = migrationEngine(someTestState)
+
+  t.same(migratedState, { myFancyStateProperty: 'B' })
 })
 
 test('should not applied migrations to the loaded state when the current version is the same', async (t) => {


### PR DESCRIPTION
This PR exposes the migration algorithm for ad-hoc testing and ad-hoc migrations (sometimes we want to apply migrations to redux's `initialState` argument as well as for loaded states).
It only adds extra arguments, with sane default values that maintain backwards compatibility.
All tests passed (after I fixed one missing dev dependency).